### PR TITLE
Fix overlapping arrows and text

### DIFF
--- a/src/Ebook.js
+++ b/src/Ebook.js
@@ -24,7 +24,7 @@ export const InitializeEbook = async (ebookUrl, playerTarget, params) => {
 
   const rendition = await book.renderTo(playerTarget, {
     height: params.height,
-    width: playerTarget.getBoundingClientRect().width - 50,
+    width: playerTarget.getBoundingClientRect().width - 65,
     spread: "always",
     flow: "paginated"
   });


### PR DESCRIPTION
Ebook rendition needs to take into account page nav button width/padding. Increasing 50 to 65, which is slightly above the total width of the buttons. Tested in 300px width and above.