### PR TITLE
Set posterUrl in playerOptions

### DIFF
--- a/src/Utils.js
+++ b/src/Utils.js
@@ -229,8 +229,7 @@ export const LoadParams = (url) => {
         tenantId: params.tenantId,
         ntpId: params.ntpId,
         ticketCode: params.ticketCode,
-        ticketSubject: params.ticketSubject,
-        posterUrl: params.posterUrl
+        ticketSubject: params.ticketSubject
       },
       sourceOptions: {
         protocols: params.protocols,
@@ -252,7 +251,8 @@ export const LoadParams = (url) => {
         muted: params.muted,
         loop: params.loop,
         watermark: params.watermark,
-        capLevelToPlayerSize: params.capLevelToPlayerSize
+        capLevelToPlayerSize: params.capLevelToPlayerSize,
+        posterUrl: params.posterUrl
       }
     }
   };


### PR DESCRIPTION
The posterUrl is read from playerOptions (not clientOptions).
Reference: https://github.com/eluv-io/elv-player-js/commit/e52c85103f6102915d70a5823bb366fb20216611